### PR TITLE
Ignore XML comments when reading manifests

### DIFF
--- a/DuplicateExtensionFinder/Program.cs
+++ b/DuplicateExtensionFinder/Program.cs
@@ -45,8 +45,7 @@
                     var manifest = Path.Combine(dir.FullName, "extension.vsixmanifest");
                     if (File.Exists(manifest))
                     {
-                        using (var file = File.OpenRead(manifest))
-                        using (var rdr = new XmlTextReader(file))
+                        using (var rdr = XmlReader.Create(manifest, new XmlReaderSettings { IgnoreComments = true }))
                         {
                             try
                             {


### PR DESCRIPTION
DuplicateExtensionFinder failed because on my machine there's an extension with a comment in its manifest:
```xml
<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011">
  <Metadata>
    <Identity Id=".NetNative.Microsoft.76F163D5-4A7A-47F7-9F5D-AA1743525C3F" Version="1.0.24208.00" Language="en-US" Publisher="Microsoft Corp." />
    <DisplayName><!-- _locID="ExtensionDisplayName" -->.NET Native VS Integration</DisplayName>
    <Description xml:space="preserve"><!-- _locID="ExtensionDescription" -->.NET Native Visual Studio Integration</Description>
  </Metadata>
  <Installation InstalledByMsi="true" AllUsers="true" SystemComponent="true">
    <InstallationTarget Id="Microsoft.VisualStudio.Pro" Version="12.0" />
  </Installation>
</PackageManifest>
```
`XmlSerializer` doesn't like reading comments by default, but by passing custom `XmlReadSettings` it works.